### PR TITLE
adding a shell for easier maintenance of Dockerfiles

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -37,7 +37,7 @@ func main() {
     fmt.Println("Hello Distroless!")
 }
 EOF
-RUN ["go", "build", "-o", "hello", "."]
+RUN go build -o hello .
 
 FROM cgr.dev/chainguard/static:latest
 

--- a/apko.yaml
+++ b/apko.yaml
@@ -7,6 +7,7 @@ contents:
     - alpine-baselayout-data
     - gcc
     - musl-dev
+    - busybox
     - go
 accounts:
   groups:


### PR DESCRIPTION
Signed-off-by: James Rawlings <jrawlings@chainguard.dev>

This was tested by running...
```
docker run --rm -v ${PWD}:/work distroless.dev/apko build /work/apko.yaml go:test /work/go-test.tar
docker load < go-test.tar
```
and changing the [example Dockerfile](https://github.com/chainguard-images/go/blob/20051f7/USAGE.md#dockerfile-example)
from
```
RUN ["go", "build", "-o", "hello", "."]
```
to 
```
RUN go build -o hello .
```
The docker build was succesful which wasn't previously.

Side note a comparison of the image size shows a minor increase..
```
➜ docker images cgr.dev/chainguard/go:latest
REPOSITORY              TAG       IMAGE ID       CREATED        SIZE
cgr.dev/chainguard/go   latest    083dc3d59477   12 hours ago   563MB

➜  docker images go:test
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
go           test      9b350cb34eb6   52 years ago   564MB
```

Closes #3.